### PR TITLE
Detect console page as success

### DIFF
--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -186,7 +186,7 @@ function doPostBack(tabid, change, tab) {
 	writeLog(tabid, change, tab);
 	if (_rlistener) {
 		if (_rtab.id == tabid) {
-			if (change.status == 'complete' && tab.url == 'https://signin.aws.amazon.com/saml' && (!(_relogrole))) {
+			if (change.status == 'complete' && (tab.url == 'https://signin.aws.amazon.com/saml' || tab.url.indexOf('console.aws.amazon.com') > 0) && (!(_relogrole))) {
 				writeLog('doPostBack ready');
 				if (!_prevInfo.userInfo) {
 					writeLog('need to invoke evalAllCookies later');


### PR DESCRIPTION
I'm using shibboleth, not AD.  I don't seem to get an update event for the saml signin url.  If i look at network traffic, it happens just issues a 302?  This just checks if console.aws.amazon.com is reached, and considers that a login as well.

11 Object {status: "loading", url: "https:/shibboleth/idp/profile/SAML2/Unsolicited/SSO"} Object {active: true, height: 702, highlighted: true, id: 211, incognito: false…}
11 Object {status: "complete"} Object {active: true, height: 702, highlighted: true, id: 211, incognito: false…}
Object {arn: "arn:...", alias: "iam", username: "assumed-role", keybase: "key"} 
Object {status: "loading", url: "https://console.aws.amazon.com/console/home?#"} Object {active: true, height: 702, highlighted: true, id: 211, incognito: false…}
