### PR TITLE
fix case for eventPage.js

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
 	},
 	"background" : {
 		"persistent" : false,
-		"scripts" : ["eventpage.js"]
+		"scripts" : ["eventPage.js"]
 	},
 	"omnibox" : {
 		"keyword" : "caster"


### PR DESCRIPTION
On Linux, it is impossbile to load the the extension, because eventpage.js is not found.
This change fixes the case.
